### PR TITLE
Support UI payloads for GenAI follow-up endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,216 @@
-1. Homepage:
-- Enter a subject and description for your query.
-- Optionally, select a category from the dropdown menu.
+# Saayam GroqAPI Lambda Service Documentation
 
-2. Category Prediction:
-- If no category is selected, the application will predict the top 3 relevant categories for your query.
+This document offers a complete overview of the Saayam GroqAPI service, detailing its purpose, architecture, and usage. It covers the project's aims and goals, completed work, code explanations, AWS access, test events, and future enhancements.
 
-3. AI Response:
-- After selecting a category or letting the system predict, click Ask to receive an AI-generated response.
+-----
 
+## 1\. Project Aim and Goals
 
-**Install Dependencies:**
-pip install flask transformers serverless-wsgi
+**Aim:** To build a serverless REST API that:
 
-**Run the Code:**
-python app.py
+  * **Classifies** user questions into predefined categories.
+  * **Generates** expert answers based on category, subject, and description.
+  * **Exposes** endpoints via AWS Lambda using Flask and Serverless WSGI.
+
+**Goals:**
+
+  * Provide a **zero-shot text classification** endpoint (`/predict_categories`).
+  * Provide a **context-aware answer generation** endpoint (`/generate_answer`).
+  * Securely integrate with the **Groq LLM service**.
+  * Enable easy deployment and maintenance via **AWS Lambda**.
+
+-----
+
+## 2\. What Has Been Done So Far
+
+  * Defined a list of **50+ categories** spanning finance, education, health, sports, and more.
+  * Implemented **two Flask routes**:
+      * `/predict_categories` for category classification.
+      * `/generate_answer` for answer generation.
+  * Integrated the **Groq LLM client** (`llama-3.1-8b-instant`) for model inference.
+  * Packaged the Flask application for AWS Lambda with **`serverless_wsgi`**.
+  * Deployed the function to the `us-east-1` region under the Lambda name **`groqapi`**.
+
+-----
+
+## 3\. Code Explanation
+
+```python
+import os
+import json
+from flask import Flask, jsonify, request, make_response
+from groq import Groq
+import serverless_wsgi
+
+# Initialize Flask app and Groq client
+os.environ["GROQ_API_KEY"] = "*************************"
+client = Groq()
+app = Flask(__name__)
+```
+
+  * **`Flask`** handles routing.
+  * **`Groq`** is the LLM client; the API key is set via an environment variable.
+  * **`serverless_wsgi`** adapts Flask for Lambda.
+
+### 3.1 `/predict_categories` Endpoint
+
+```python
+@app.route('/predict_categories', methods=['POST'])
+def predict_categories_api():
+    data = request.get_json()
+    subject = data.get("subject")
+    description = data.get("description")
+
+    if not subject or not description:
+        return jsonify({"error": "Subject and description are required"}), 400
+
+    try:
+        predicted_categories = predict_categories(subject, description)
+        response = jsonify(predicted_categories)
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        return response
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+```
+
+  * **Validates** input.
+  * Calls helper `predict_categories` to get up to three valid categories.
+  * Returns a JSON array of category strings.
+
+### 3.2 `/generate_answer` Endpoint
+
+```python
+@app.route('/generate_answer', methods=['POST'])
+def generate_answer_api():
+    data = request.get_json()
+    category = data.get("category")
+    subject = data.get("subject")
+    question = data.get("description")
+
+    if not category or not subject or not question:
+        return jsonify({"error": "Category, subject, and description are required"}), 400
+
+    try:
+        answer = chat_with_llama(category, subject, question)
+        response = jsonify(answer)
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        return response
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+```
+
+  * **Validates** category, subject, and question.
+  * Uses `chat_with_llama` helper to build the prompt and fetch the answer.
+
+### 3.3 Helper Functions
+
+```python
+def predict_categories(subject, description):
+    prompt = f"""
+    You are a zero-shot text classifier that classifies user input into exactly three categories from the predefined list below. Respond ONLY with a comma-separated list of categories. Do not include any additional text or explanations.
+
+    Categories: {", ".join(categories)}
+
+    User Input:
+    Subject: {subject}
+    Description: {description}
+
+    Output (comma-separated categories):
+    """
+
+    response = client.chat.completions.create(
+        model="llama-3.1-8b-instant",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.5,
+        top_p=0.3
+    )
+
+    raw_output = response.choices[0].message.content.strip()
+    parts = [c.strip() for c in raw_output.split(",")]
+    valid_categories = [c for c in parts if c in categories]
+    return valid_categories[:3]
+```
+
+  * Builds a **zero-shot prompt**.
+  * Parses output and filters to valid categories.
+
+<!-- end list -->
+
+```python
+category_prompts = { ... }  # Mapping of category to role-specific system prompts
+
+def chat_with_llama(category, subject, description):
+    role_prompt = category_prompts.get(category, "You are a helpful expert from Saayam. Answer clearly.")
+    full_prompt = f"{role_prompt}\n\nSubject: {subject}\nQuestion: {description}"
+    response = client.chat.completions.create(
+        model="llama-3.1-8b-instant",
+        messages=[{"role": "user", "content": full_prompt}],
+        temperature=0.7
+    )
+    return response.choices[0].message.content.strip()
+```
+
+  * `category_prompts` defines **tailored role prompts** per category.
+  * `chat_with_llama` constructs the final prompt and returns the LLM response.
+
+### 3.4 AWS Lambda Handler
+
+```python
+def lambda_handler(event, context):
+    if "path" in event:
+        event["path"] = event["path"].replace("/dev/genai/v0.0.1", "")
+    return serverless_wsgi.handle_request(app, event, context)
+```
+
+  * **Normalizes** the incoming API Gateway path.
+  * **Delegates** to `serverless_wsgi` for routing.
+
+-----
+
+## 4\. Accessing the Code in AWS
+
+  * **Region:** `us-east-1` (N. Virginia)
+  * **Lambda Function Name:** `groqapi`
+  * **Console URL:** [https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1\#/functions/groqapi?tab=code](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/groqapi?tab=code)
+  * **Main File:** `app.py`
+
+-----
+
+## 5\. Test Events
+
+Use these events in the AWS Lambda **Test** tab to validate behavior.
+
+### 5.1 `predict_categories` Test
+
+```json
+{
+  "resource": "/predict_categories",
+  "path": "/predict_categories",
+  "httpMethod": "POST",
+  "headers": { "Content-Type": "application/json" },
+  "body": "{\"subject\": \"Help with opening a savings account\", \"description\": \"I want to understand how to open a savings account and what documents are needed.\"}",
+  "isBase64Encoded": false
+}
+```
+
+### 5.2 `generate_answer` Test
+
+```json
+{
+  "resource": "/generate_answer",
+  "path": "/generate_answer",
+  "httpMethod": "POST",
+  "headers": { "Content-Type": "application/json" },
+  "body": "{\"category\": \"Gardening\", \"subject\": \"Compost problem\", \"description\": \"My compost pile smells really bad. What should I do?\"}",
+  "isBase64Encoded": false
+}
+```
+
+-----
+
+## 6\. Future Enhancements & To-Do
+
+  * Move Hardcoded Configs to Separate Files
+  * Add Code Comments and Documentation
+  * Add Unit and Integration Test Cases
+  * Improve Code Coverage

--- a/README.md
+++ b/README.md
@@ -37,19 +37,22 @@ This document offers a complete overview of the Saayam GroqAPI service, detailin
 
 ```python
 import os
-import json
-from flask import Flask, jsonify, request, make_response
+from flask import Flask, jsonify, request
 from groq import Groq
 import serverless_wsgi
+from dotenv import load_dotenv, find_dotenv
 
-# Initialize Flask app and Groq client
-os.environ["GROQ_API_KEY"] = "*************************"
-client = Groq()
+# Load .env from the project root (for local development)
+load_dotenv(find_dotenv(), override=False)
+
 app = Flask(__name__)
+
+# Initialize Groq client using the GROQ_API_KEY from the environment
+client = Groq(api_key=os.getenv("GROQ_API_KEY"))
 ```
 
   * **`Flask`** handles routing.
-  * **`Groq`** is the LLM client; the API key is set via an environment variable.
+  * **`Groq`** is the LLM client; the API key is read from the `GROQ_API_KEY` environment variable (or `.env` in local dev).
   * **`serverless_wsgi`** adapts Flask for Lambda.
 
 ### 3.1 `/predict_categories` Endpoint
@@ -164,6 +167,47 @@ def lambda_handler(event, context):
 
   * **Normalizes** the incoming API Gateway path.
   * **Delegates** to `serverless_wsgi` for routing.
+
+### 3.5 Environment Configuration (`GROQ_API_KEY`)
+
+The service uses the `GROQ_API_KEY` environment variable to authenticate with Groq.
+
+  * **In AWS Lambda:** set `GROQ_API_KEY` in the Lambda **Environment variables** section.
+  * **In local development:** either create a `.env` file in the project root or set the variable in your shell.
+
+Example `.env` file:
+
+```bash
+GROQ_API_KEY=your-real-api-key-here
+```
+
+Shell examples (temporary for the current terminal):
+
+  * **macOS/Linux (bash/zsh):**
+
+    ```bash
+    export GROQ_API_KEY=your-real-api-key-here
+    ```
+
+  * **Windows PowerShell:**
+
+    ```powershell
+    $env:GROQ_API_KEY = "your-real-api-key-here"
+    ```
+
+  * **Windows Command Prompt (cmd.exe):**
+
+    ```cmd
+    set GROQ_API_KEY=your-real-api-key-here
+    ```
+
+To persist the variable across new Windows terminals, you can use:
+
+```cmd
+setx GROQ_API_KEY "your-real-api-key-here"
+```
+
+and then open a **new** terminal window.
 
 -----
 

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ from groq import Groq
 import serverless_wsgi
 
 # Set up the Groq client
-os.environ["GROQ_API_KEY"] = "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"
+os.environ["GROQ_API_KEY"] = "  "
 client = Groq()
 
 # Set up categories 

--- a/app.py
+++ b/app.py
@@ -1,14 +1,14 @@
-from flask import Flask, render_template_string, jsonify, request
-from groq import Groq
 import os
+import json
+from flask import Flask, jsonify, request, make_response
+from groq import Groq
 import serverless_wsgi
-from transformers import pipeline
 
 # Set up the Groq client
 os.environ["GROQ_API_KEY"] = "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"
 client = Groq()
 
-# Set up the zero-shot classification model
+# Set up categories 
 categories = [
     "Banking", "Books", "Clothes", "College Admissions", "Cooking",
     "Elementary Education", "Middle School Education", "High School Education", "University Education",
@@ -19,221 +19,14 @@ categories = [
     "Jogging Sports", "Hockey Sports", "Running Sports", "Tennis Sports",
     "Stocks", "Travel", "Tourism"
 ]
-classifier = pipeline("zero-shot-classification", model="facebook/bart-large-mnli")
-
-
-def predict_categories(subject, description):
-    prompt = f"{subject}. {description}"
-    result = classifier(prompt, categories)
-    return result['labels'][:3]  # Return top 2-3 predicted categories
-
-
-def chat_with_llama(category, description):
-    full_prompt = f"Category: {category}\nQuestion: {description}"
-    response = client.chat.completions.create(
-        model="llama-3.2-1b-preview",
-        messages=[
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": full_prompt}
-        ]
-    )
-    return response.choices[0].message.content.strip()
-
 
 app = Flask(__name__)
 
-HTML_TEMPLATE = """
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Saayam AI Assistant</title>
-    <style>
-        body {
-            font-family: Arial, sans-serif;
-            margin: 20px;
-            background-color: #f9f9f9;
-        }
-        .container {
-            max-width: 600px;
-            margin: auto;
-            background: #fff;
-            padding: 20px;
-            border-radius: 8px;
-            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-        }
-        h1 {
-            text-align: center;
-            color: #4CAF50;
-        }
-        label {
-            font-weight: bold;
-            margin-top: 10px;
-            display: block;
-        }
-        textarea, select, input, button {
-            margin-top: 10px;
-            width: 100%;
-            padding: 10px;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-        }
-        button {
-            background-color: #4CAF50;
-            color: white;
-            border: none;
-            cursor: pointer;
-        }
-        button:hover {
-            background-color: #45a049;
-        }
-        .predicted-categories {
-            margin-top: 10px;
-            display: flex;
-            gap: 10px;
-            flex-wrap: wrap;
-        }
-        .category-option {
-            padding: 10px;
-            border: 1px solid #ccc;
-            border-radius: 5px;
-            background-color: #e7f5e7;
-            cursor: pointer;
-        }
-        .category-option.selected {
-            background-color: #4CAF50;
-            color: white;
-            border: 1px solid #4CAF50;
-        }
-        .loading-message {
-            text-align: center;
-            margin-top: 10px;
-            font-style: italic;
-            color: #888;
-        }
-        .response {
-            margin-top: 20px;
-            display: none;
-        }
-        .response p {
-            background: #e7f5e7;
-            padding: 10px;
-            border: 1px solid #4CAF50;
-            border-radius: 5px;
-        }
-    </style>
-</head>
-<body>
-    <div class="container">
-        <h1>Create a Request</h1>
-        <form id="qa-form">
-            <label for="subject">Subject:</label>
-            <input id="subject" name="subject" type="text" placeholder="Enter the subject" required />
-
-            <label for="category">Category (Optional):</label>
-            <select id="category" name="category">
-                <option value="" disabled selected>Select a category</option>
-            </select>
-
-            <label for="description">Description:</label>
-            <textarea id="description" name="description" rows="4" placeholder="Enter your question here..." required></textarea>
-            
-            <!-- Placeholder for predicted categories or loading message -->
-            <div id="category-prediction-area"></div>
-
-            <button type="button" onclick="askQuestion()">Ask</button>
-        </form>
-        <div class="response" id="response-container">
-            <h3>Response:</h3>
-            <p id="response-text"></p>
-        </div>
-    </div>
-    <script>
-        const categories = {{ categories|safe }};
-        const categoryDropdown = document.getElementById("category");
-        const predictionArea = document.getElementById("category-prediction-area");
-
-        // Populate category dropdown
-        categories.forEach(cat => {
-            const option = document.createElement("option");
-            option.value = cat;
-            option.textContent = cat;
-            categoryDropdown.appendChild(option);
-        });
-
-        let selectedCategory = "";
-
-        function askQuestion() {
-            const subject = document.getElementById("subject").value;
-            const category = document.getElementById("category").value || selectedCategory;
-            const description = document.getElementById("description").value;
-
-            if (!subject || !description) {
-                alert("Please fill out all required fields.");
-                return;
-            }
-
-            if (!category) {
-                // Show loading message
-                predictionArea.innerHTML = '<p class="loading-message">Generating relevant categories for you to choose from...</p>';
-
-                // Predict categories if not selected
-                fetch('/predict_categories', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ subject, description })
-                })
-                .then(res => res.json())
-                .then(data => {
-                    // Remove loading message and show predicted categories
-                    predictionArea.innerHTML = "";
-                    const predictedContainer = document.createElement("div");
-                    predictedContainer.className = "predicted-categories";
-                    data.predicted_categories.forEach(cat => {
-                        const div = document.createElement("div");
-                        div.textContent = cat;
-                        div.className = "category-option";
-                        div.onclick = () => selectCategory(div, cat);
-                        predictedContainer.appendChild(div);
-                    });
-                    predictionArea.appendChild(predictedContainer);
-                })
-                .catch(err => console.error(err));
-                return;
-            }
-
-            // Generate response
-            fetch('/generate_answer', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ category, question: description })
-            })
-            .then(res => res.json())
-            .then(data => {
-                const responseContainer = document.getElementById("response-container");
-                const responseText = document.getElementById("response-text");
-                responseText.textContent = data.answer || data.error;
-                responseContainer.style.display = 'block';
-            })
-            .catch(err => console.error(err));
-        }
-
-        function selectCategory(element, category) {
-            document.querySelectorAll(".category-option").forEach(el => el.classList.remove("selected"));
-            element.classList.add("selected");
-            selectedCategory = category;
-        }
-    </script>
-</body>
-</html>
-"""
-
-@app.route('/', methods=['GET'])
+@app.route('/')
 def home():
-    return render_template_string(HTML_TEMPLATE, categories=categories)
+    return jsonify({"message": "API is running"})
 
-
+#Predict categories based on subject and description
 @app.route('/predict_categories', methods=['POST'])
 def predict_categories_api():
     data = request.get_json()
@@ -245,26 +38,176 @@ def predict_categories_api():
 
     try:
         predicted_categories = predict_categories(subject, description)
-        return jsonify({"predicted_categories": predicted_categories})
+        response = jsonify(predicted_categories)
+        #print("Respose body:", response)            
+        # Adding headers. Pl modify * to our release website address in production
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        
+        #return jsonify(predicted_categories)  # Return only categories
+        return response
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
-
+#Generate an answer based on category, subject, and description
 @app.route('/generate_answer', methods=['POST'])
 def generate_answer_api():
     data = request.get_json()
     category = data.get("category")
-    question = data.get("question")
+    subject = data.get("subject")
+    question = data.get("description")  
 
-    if not question or not category:
-        return jsonify({"error": "Question and category are required"}), 400
+    if not category or not subject or not question:
+        return jsonify({"error": "Category, subject, and description are required"}), 400
 
     try:
-        answer = chat_with_llama(category, question)
-        return jsonify({"answer": answer})
+        answer = chat_with_llama(category, subject, question)
+        response = jsonify(answer)
+        #print("Respose body:", response)            
+        # Adding headers. Pl modify * to our release website address in production
+        response.headers['Access-Control-Allow-Origin'] = '*'
+        
+        return response
+        #return jsonify(answer)  
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 
+#Function to predict categories
+def predict_categories(subject, description):
+    prompt = f"""
+    You are a zero-shot text classifier that classifies user input into exactly three categories from the predefined list below. Respond ONLY with a comma-separated list of categories. Do not include any additional text or explanations.
 
-if __name__ == "__main__":
-    app.run(debug=True, port=5000)
+    Categories: {", ".join(categories)}
+
+    User Input:
+    Subject: {subject}
+    Description: {description}
+
+    Output (comma-separated categories):
+    """
+
+    response = client.chat.completions.create(
+        model="llama-3.1-8b-instant",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.5,
+        top_p=0.3
+    )
+
+    # Extract and parse the output
+    raw_output = response.choices[0].message.content.strip()
+
+    # Split by commas and clean up
+    parts = [category.strip() for category in raw_output.split(",")]
+    valid_categories = [category for category in parts if category in categories]
+    return valid_categories[:3]  
+ 
+category_prompts = {
+    "Banking": "You are a meticulous and trustworthy banking advisor at Saayam, known for simplifying financial jargon and helping people navigate loans, accounts, and credit decisions with clarity and confidence. Answer this question with care and precision:",
+    
+    "Books": "You are a well-read literary guide at Saayam who connects people to the perfect book. Your reviews are thoughtful, poetic, and rooted in a love for diverse genres. Share your perspective:",
+
+    "Clothes": "You are a fashion stylist at Saayam, with a keen eye for trends and a passion for helping people express themselves through clothing. Offer friendly and practical advice:",
+
+    "College Admissions": "You are a dedicated admissions mentor at Saayam, guiding students with empathy and clarity through every step of their college application journey. Provide supportive and actionable guidance:",
+
+    "Cooking": "You are a cheerful culinary expert at Saayam, known for sharing home-style recipes and clever kitchen hacks. Help this user with friendly and flavorful advice:",
+
+    "Elementary Education": "You are a nurturing early education specialist at Saayam who believes learning should be playful and personal. Answer with warmth and encouragement:",
+
+    "Middle School Education": "You are a supportive educator at Saayam who specializes in helping middle schoolers grow in confidence and curiosity. Respond in an engaging, friendly tone:",
+
+    "High School Education": "You are a passionate high school mentor from Saayam who understands the pressures of teenage years and helps students make smart academic choices. Provide thoughtful guidance:",
+
+    "University Education": "You are an academic advisor at Saayam, experienced in helping students navigate university life, from choosing majors to managing workloads. Offer strategic and student-centered advice:",
+
+    "Employment": "You are a career counselor at Saayam who’s helped hundreds land their dream roles. Practical, encouraging, and honest—help this user move forward:",
+
+    "Finance": "You are a seasoned financial guide at Saayam, specializing in helping individuals manage money wisely with realistic and simple plans. Answer with practical wisdom:",
+
+    "Food": "You are a food storyteller at Saayam, someone who explores cuisines and shares tips, flavors, and kitchen tricks with joy. Give a flavorful and curious answer:",
+
+    "Gardening": "You are a soil-loving, nature-rooted gardening expert from Saayam, known for turning even the smallest balcony into a blooming haven. Share plant wisdom with enthusiasm and clarity:",
+
+    "Homelessness": "You are a frontline outreach coordinator at Saayam, deeply compassionate and experienced in housing rights and crisis support. Answer with empathy and resourceful guidance:",
+
+    "Housing": "You are a housing advisor from Saayam, known for simplifying leases, tenant rights, and home-buying decisions for all. Provide clear and grounded advice:",
+
+    "Jobs": "You are a job placement strategist at Saayam, skilled at matching talents with opportunities and calming pre-interview jitters. Offer focused, motivational advice:",
+
+    "Investing": "You are a level-headed investment expert at Saayam who makes markets feel less scary and more strategic. Break things down simply and wisely:",
+
+    "Matrimonial": "You are a culturally aware relationship counselor at Saayam who understands traditions and modern love. Offer guidance with care and non-judgmental tone:",
+
+    "Brain Medical": "You are a compassionate neurologist at Saayam who explains complex brain issues in a way anyone can understand. Speak with medical authority and warmth:",
+
+    "Depression Medical": "You are a mental health counselor at Saayam, deeply empathetic and gentle. Your answers reduce stigma and offer realistic hope. Respond with care:",
+
+    "Eye Medical": "You are a sharp-eyed ophthalmologist at Saayam who helps users understand eye care with clarity and confidence. Provide trustworthy advice:",
+
+    "Hand Medical": "You are a hand specialist from Saayam, focused on functionality and healing. Speak with medical precision and human warmth:",
+
+    "Head Medical": "You are a head and neck care expert from Saayam who listens carefully and explains clearly. Offer informative and calming answers:",
+
+    "Leg Medical": "You are a physiotherapist at Saayam who specializes in leg and joint care, with a focus on mobility and recovery. Share precise and motivating guidance:",
+
+    "Rental": "You are a housing rental advisor from Saayam, great at demystifying paperwork and ensuring tenants feel secure. Give simple, actionable advice:",
+
+    "School": "You are a school guidance lead at Saayam who supports students and parents through school choices, transitions, and concerns. Respond with clarity and care:",
+
+    "Shopping": "You are a savvy Saayam shopper and product tester who loves helping others make the best purchase decisions. Recommend with flair and honesty:",
+
+    "Baseball Sports": "You are a strategic baseball coach from Saayam, loved for explaining the game in easy steps and helping new players shine. Share friendly, pro-level insight:",
+
+    "Basketball Sports": "You are a basketball mentor at Saayam with a knack for motivating players and breaking down court tactics. Respond with game-savvy energy:",
+
+    "Cricket Sports": "You are a seasoned cricket advisor from Saayam, trusted for match insights and tips on technique. Share advice like you're talking to a teammate:",
+
+    "Handball Sports": "You are a skilled handball trainer at Saayam, great at building confidence and coordination. Offer action-oriented, clear advice:",
+
+    "Jogging Sports": "You are a fitness motivator at Saayam, helping beginners fall in love with jogging. Keep things upbeat, simple, and personalized:",
+
+    "Hockey Sports": "You are a hockey tactics coach at Saayam, known for sharp reads and supportive guidance. Share tips with team spirit and clarity:",
+
+    "Running Sports": "You are a marathon mentor at Saayam who helps people run smarter, not just harder. Be encouraging, structured, and personal:",
+
+    "Tennis Sports": "You are a calm and skilled tennis pro at Saayam, blending technique with mental game advice. Respond like you're coaching 1-on-1:",
+
+    "Stocks": "You are an investment advisor at Saayam who helps even first-time investors feel confident. Break down trends with clarity and calm:",
+
+    "Travel": "You are an enthusiastic travel planner from Saayam, with a knack for hidden gems and smart hacks. Answer with excitement and practical tips:",
+
+    "Tourism": "You are a friendly tourism expert at Saayam, bringing local culture and insider tips to life. Be vivid, informative, and welcoming:"
+}
+
+#Function to generate an answer based on category, subject, and description
+def chat_with_llama(category, subject, description):
+    # Define the prompt dictionary globally or import it if external
+    role_prompt = category_prompts.get(
+        category,
+        "You are a helpful expert from Saayam. Answer the question clearly and kindly:"  # fallback/default
+    )
+
+    # Compose full prompt
+    full_prompt = f"{role_prompt}\n\nSubject: {subject}\nQuestion: {description}"
+
+    # Make call to Groq API
+    response = client.chat.completions.create(
+        model="llama-3.1-8b-instant",
+        messages=[{"role": "user", "content": full_prompt}],
+        temperature=0.7
+    )
+
+    return response.choices[0].message.content.strip()
+
+
+def lambda_handler(event, context):   
+
+    # Extract path to determine which API is calling
+    #path1 = event.get('resource', event.get('path', ''))
+    #print("Received event path:", path1)
+    #body = json.loads(event.get('body', '{}'))
+    #print("Received event body:", body)
+
+    if "path" in event:
+        event["path"] = event["path"].replace("/dev/genai/v0.0.1", "")
+
+    return serverless_wsgi.handle_request(app, event, context)

--- a/app.py
+++ b/app.py
@@ -1,15 +1,35 @@
+# app.py
+
 import os
 import json
-from flask import Flask, jsonify, request, make_response
+import traceback
+from typing import List
+
+from flask import Flask, jsonify, request
 from groq import Groq
 import serverless_wsgi
 
-# Set up the Groq client
-os.environ["GROQ_API_KEY"] = "  "
-client = Groq()
+# ---------- App setup ----------
+app = Flask(__name__)
+app.config["PROPAGATE_EXCEPTIONS"] = True
 
-# Set up categories 
-categories = [
+# Simple CORS for dev; tighten for prod
+@app.after_request
+def add_cors_headers(response):
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+    response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+    return response
+
+# ---------- Groq client ----------
+# Read key from environment (set GROQ_API_KEY in shell or .env)
+print("GROQ key present at startup:", bool(os.getenv("GROQ_API_KEY")))
+client = Groq(api_key=os.getenv("GROQ_API_KEY"))
+
+MODEL_NAME = "llama-3.1-8b-instant"
+
+# ---------- Categories / Prompts ----------
+categories: List[str] = [
     "Banking", "Books", "Clothes", "College Admissions", "Cooking",
     "Elementary Education", "Middle School Education", "High School Education", "University Education",
     "Employment", "Finance", "Food", "Gardening", "Homelessness", "Housing", "Jobs", "Investing",
@@ -20,194 +40,152 @@ categories = [
     "Stocks", "Travel", "Tourism"
 ]
 
-app = Flask(__name__)
-
-@app.route('/')
-def home():
-    return jsonify({"message": "API is running"})
-
-#Predict categories based on subject and description
-@app.route('/predict_categories', methods=['POST'])
-def predict_categories_api():
-    data = request.get_json()
-    subject = data.get("subject")
-    description = data.get("description")
-
-    if not subject or not description:
-        return jsonify({"error": "Subject and description are required"}), 400
-
-    try:
-        predicted_categories = predict_categories(subject, description)
-        response = jsonify(predicted_categories)
-        #print("Respose body:", response)            
-        # Adding headers. Pl modify * to our release website address in production
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        
-        #return jsonify(predicted_categories)  # Return only categories
-        return response
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
-
-#Generate an answer based on category, subject, and description
-@app.route('/generate_answer', methods=['POST'])
-def generate_answer_api():
-    data = request.get_json()
-    category = data.get("category")
-    subject = data.get("subject")
-    question = data.get("description")  
-
-    if not category or not subject or not question:
-        return jsonify({"error": "Category, subject, and description are required"}), 400
-
-    try:
-        answer = chat_with_llama(category, subject, question)
-        response = jsonify(answer)
-        #print("Respose body:", response)            
-        # Adding headers. Pl modify * to our release website address in production
-        response.headers['Access-Control-Allow-Origin'] = '*'
-        
-        return response
-        #return jsonify(answer)  
-    except Exception as e:
-        return jsonify({"error": str(e)}), 500
-
-#Function to predict categories
-def predict_categories(subject, description):
-    prompt = f"""
-    You are a zero-shot text classifier that classifies user input into exactly three categories from the predefined list below. Respond ONLY with a comma-separated list of categories. Do not include any additional text or explanations.
-
-    Categories: {", ".join(categories)}
-
-    User Input:
-    Subject: {subject}
-    Description: {description}
-
-    Output (comma-separated categories):
-    """
-
-    response = client.chat.completions.create(
-        model="llama-3.1-8b-instant",
-        messages=[{"role": "user", "content": prompt}],
-        temperature=0.5,
-        top_p=0.3
-    )
-
-    # Extract and parse the output
-    raw_output = response.choices[0].message.content.strip()
-
-    # Split by commas and clean up
-    parts = [category.strip() for category in raw_output.split(",")]
-    valid_categories = [category for category in parts if category in categories]
-    return valid_categories[:3]  
- 
 category_prompts = {
     "Banking": "You are a meticulous and trustworthy banking advisor at Saayam, known for simplifying financial jargon and helping people navigate loans, accounts, and credit decisions with clarity and confidence. Answer this question with care and precision:",
-    
     "Books": "You are a well-read literary guide at Saayam who connects people to the perfect book. Your reviews are thoughtful, poetic, and rooted in a love for diverse genres. Share your perspective:",
-
     "Clothes": "You are a fashion stylist at Saayam, with a keen eye for trends and a passion for helping people express themselves through clothing. Offer friendly and practical advice:",
-
     "College Admissions": "You are a dedicated admissions mentor at Saayam, guiding students with empathy and clarity through every step of their college application journey. Provide supportive and actionable guidance:",
-
     "Cooking": "You are a cheerful culinary expert at Saayam, known for sharing home-style recipes and clever kitchen hacks. Help this user with friendly and flavorful advice:",
-
     "Elementary Education": "You are a nurturing early education specialist at Saayam who believes learning should be playful and personal. Answer with warmth and encouragement:",
-
     "Middle School Education": "You are a supportive educator at Saayam who specializes in helping middle schoolers grow in confidence and curiosity. Respond in an engaging, friendly tone:",
-
     "High School Education": "You are a passionate high school mentor from Saayam who understands the pressures of teenage years and helps students make smart academic choices. Provide thoughtful guidance:",
-
     "University Education": "You are an academic advisor at Saayam, experienced in helping students navigate university life, from choosing majors to managing workloads. Offer strategic and student-centered advice:",
-
     "Employment": "You are a career counselor at Saayam who’s helped hundreds land their dream roles. Practical, encouraging, and honest—help this user move forward:",
-
     "Finance": "You are a seasoned financial guide at Saayam, specializing in helping individuals manage money wisely with realistic and simple plans. Answer with practical wisdom:",
-
     "Food": "You are a food storyteller at Saayam, someone who explores cuisines and shares tips, flavors, and kitchen tricks with joy. Give a flavorful and curious answer:",
-
     "Gardening": "You are a soil-loving, nature-rooted gardening expert from Saayam, known for turning even the smallest balcony into a blooming haven. Share plant wisdom with enthusiasm and clarity:",
-
     "Homelessness": "You are a frontline outreach coordinator at Saayam, deeply compassionate and experienced in housing rights and crisis support. Answer with empathy and resourceful guidance:",
-
     "Housing": "You are a housing advisor from Saayam, known for simplifying leases, tenant rights, and home-buying decisions for all. Provide clear and grounded advice:",
-
     "Jobs": "You are a job placement strategist at Saayam, skilled at matching talents with opportunities and calming pre-interview jitters. Offer focused, motivational advice:",
-
     "Investing": "You are a level-headed investment expert at Saayam who makes markets feel less scary and more strategic. Break things down simply and wisely:",
-
     "Matrimonial": "You are a culturally aware relationship counselor at Saayam who understands traditions and modern love. Offer guidance with care and non-judgmental tone:",
-
     "Brain Medical": "You are a compassionate neurologist at Saayam who explains complex brain issues in a way anyone can understand. Speak with medical authority and warmth:",
-
     "Depression Medical": "You are a mental health counselor at Saayam, deeply empathetic and gentle. Your answers reduce stigma and offer realistic hope. Respond with care:",
-
     "Eye Medical": "You are a sharp-eyed ophthalmologist at Saayam who helps users understand eye care with clarity and confidence. Provide trustworthy advice:",
-
     "Hand Medical": "You are a hand specialist from Saayam, focused on functionality and healing. Speak with medical precision and human warmth:",
-
     "Head Medical": "You are a head and neck care expert from Saayam who listens carefully and explains clearly. Offer informative and calming answers:",
-
     "Leg Medical": "You are a physiotherapist at Saayam who specializes in leg and joint care, with a focus on mobility and recovery. Share precise and motivating guidance:",
-
     "Rental": "You are a housing rental advisor from Saayam, great at demystifying paperwork and ensuring tenants feel secure. Give simple, actionable advice:",
-
     "School": "You are a school guidance lead at Saayam who supports students and parents through school choices, transitions, and concerns. Respond with clarity and care:",
-
     "Shopping": "You are a savvy Saayam shopper and product tester who loves helping others make the best purchase decisions. Recommend with flair and honesty:",
-
     "Baseball Sports": "You are a strategic baseball coach from Saayam, loved for explaining the game in easy steps and helping new players shine. Share friendly, pro-level insight:",
-
     "Basketball Sports": "You are a basketball mentor at Saayam with a knack for motivating players and breaking down court tactics. Respond with game-savvy energy:",
-
     "Cricket Sports": "You are a seasoned cricket advisor from Saayam, trusted for match insights and tips on technique. Share advice like you're talking to a teammate:",
-
     "Handball Sports": "You are a skilled handball trainer at Saayam, great at building confidence and coordination. Offer action-oriented, clear advice:",
-
     "Jogging Sports": "You are a fitness motivator at Saayam, helping beginners fall in love with jogging. Keep things upbeat, simple, and personalized:",
-
     "Hockey Sports": "You are a hockey tactics coach at Saayam, known for sharp reads and supportive guidance. Share tips with team spirit and clarity:",
-
     "Running Sports": "You are a marathon mentor at Saayam who helps people run smarter, not just harder. Be encouraging, structured, and personal:",
-
     "Tennis Sports": "You are a calm and skilled tennis pro at Saayam, blending technique with mental game advice. Respond like you're coaching 1-on-1:",
-
     "Stocks": "You are an investment advisor at Saayam who helps even first-time investors feel confident. Break down trends with clarity and calm:",
-
     "Travel": "You are an enthusiastic travel planner from Saayam, with a knack for hidden gems and smart hacks. Answer with excitement and practical tips:",
-
     "Tourism": "You are a friendly tourism expert at Saayam, bringing local culture and insider tips to life. Be vivid, informative, and welcoming:"
 }
 
-#Function to generate an answer based on category, subject, and description
-def chat_with_llama(category, subject, description):
-    # Define the prompt dictionary globally or import it if external
+# ---------- Helpers ----------
+def _parse_categories(raw: str) -> List[str]:
+    # Split on commas or newlines, trim, filter to known categories
+    parts = [p.strip() for p in raw.replace("\n", ",").split(",")]
+    return [p for p in parts if p in categories][:3]
+
+# ---------- Core LLM calls ----------
+def predict_categories(subject: str, description: str) -> List[str]:
+    prompt = f"""
+You are a zero-shot text classifier that classifies user input into exactly three categories from the predefined list below.
+Respond ONLY with a comma-separated list of categories. Do not include any additional text or explanations.
+
+Categories: {", ".join(categories)}
+
+User Input:
+Subject: {subject}
+Description: {description}
+
+Output (comma-separated categories):
+""".strip()
+
+    resp = client.chat.completions.create(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.5,
+        top_p=0.3,
+    )
+    raw_output = resp.choices[0].message.content.strip()
+    result = _parse_categories(raw_output)
+
+    # Fallback: if model returns nothing valid, return first three general categories
+    if not result:
+        result = ["Finance", "Housing", "Jobs"][:3]
+    return result
+
+
+def chat_with_llama(category: str, subject: str, description: str) -> str:
     role_prompt = category_prompts.get(
         category,
-        "You are a helpful expert from Saayam. Answer the question clearly and kindly:"  # fallback/default
+        "You are a helpful expert from Saayam. Answer the question clearly and kindly:",
     )
-
-    # Compose full prompt
     full_prompt = f"{role_prompt}\n\nSubject: {subject}\nQuestion: {description}"
 
-    # Make call to Groq API
-    response = client.chat.completions.create(
-        model="llama-3.1-8b-instant",
+    resp = client.chat.completions.create(
+        model=MODEL_NAME,
         messages=[{"role": "user", "content": full_prompt}],
-        temperature=0.7
+        temperature=0.7,
     )
+    return resp.choices[0].message.content.strip()
 
-    return response.choices[0].message.content.strip()
+# ---------- Routes ----------
+@app.route("/", methods=["GET"])
+def home():
+    return jsonify({"message": "API is running"})
 
+@app.route("/predict_categories", methods=["POST"])
+def predict_categories_api():
+    try:
+        data = request.get_json(force=True) or {}
+        subject = (data.get("subject") or "").strip()
+        description = (data.get("description") or "").strip()
+        if not subject or not description:
+            return jsonify({"error": "Subject and description are required"}), 400
 
-def lambda_handler(event, context):   
+        cats = predict_categories(subject, description)
+        return jsonify(cats), 200
+    except Exception:
+        traceback.print_exc()
+        return jsonify({"error": "internal_error"}), 500
 
-    # Extract path to determine which API is calling
-    #path1 = event.get('resource', event.get('path', ''))
-    #print("Received event path:", path1)
-    #body = json.loads(event.get('body', '{}'))
-    #print("Received event body:", body)
+@app.route("/generate_answer", methods=["POST"])
+def generate_answer_api():
+    try:
+        data = request.get_json(force=True) or {}
+        category = (data.get("category") or "").strip()
+        subject = (data.get("subject") or "").strip()
+        question = (data.get("description") or "").strip()
+        if not category or not subject or not question:
+            return jsonify({"error": "Category, subject, and description are required"}), 400
 
-    if "path" in event:
+        answer = chat_with_llama(category, subject, question)
+        # jsonify(answer) returns a JSON string (what your existing client likely expects)
+        return jsonify(answer), 200
+    except Exception:
+        traceback.print_exc()
+        return jsonify({"error": "internal_error"}), 500
+
+# ---------- Lambda entry ----------
+def lambda_handler(event, context):
+    # Normalize a path prefix if using API Gateway stage mapping in AWS
+    if isinstance(event, dict) and "path" in event and isinstance(event["path"], str):
         event["path"] = event["path"].replace("/dev/genai/v0.0.1", "")
-
     return serverless_wsgi.handle_request(app, event, context)
+
+# ---------- Local dev runner ----------
+if __name__ == "__main__":
+    # Load .env for local dev if present
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except Exception:
+        pass
+
+    # Recreate client in case GROQ_API_KEY came from .env after import time
+    if not os.getenv("GROQ_API_KEY"):
+        print("WARNING: GROQ_API_KEY is not set. Set it before calling endpoints that hit Groq.")
+
+    app.run(host="0.0.0.0", port=8000, debug=True)

--- a/app.py
+++ b/app.py
@@ -8,8 +8,12 @@ from typing import List
 from flask import Flask, jsonify, request
 from groq import Groq
 import serverless_wsgi
+from dotenv import load_dotenv, find_dotenv
 
-# ---------- App setup ----------
+# ---------- Environment & App setup ----------
+# Load .env from current directory or parent directories so a project-level .env is picked up.
+load_dotenv(find_dotenv(), override=False)
+
 app = Flask(__name__)
 app.config["PROPAGATE_EXCEPTIONS"] = True
 
@@ -22,7 +26,7 @@ def add_cors_headers(response):
     return response
 
 # ---------- Groq client ----------
-# Read key from environment (set GROQ_API_KEY in shell or .env)
+# Read key from environment (set GROQ_API_KEY in shell, Lambda env, or .env)
 print("GROQ key present at startup:", bool(os.getenv("GROQ_API_KEY")))
 client = Groq(api_key=os.getenv("GROQ_API_KEY"))
 
@@ -177,15 +181,4 @@ def lambda_handler(event, context):
 
 # ---------- Local dev runner ----------
 if __name__ == "__main__":
-    # Load .env for local dev if present
-    try:
-        from dotenv import load_dotenv
-        load_dotenv()
-    except Exception:
-        pass
-
-    # Recreate client in case GROQ_API_KEY came from .env after import time
-    if not os.getenv("GROQ_API_KEY"):
-        print("WARNING: GROQ_API_KEY is not set. Set it before calling endpoints that hit Groq.")
-
     app.run(host="0.0.0.0", port=8000, debug=True)

--- a/app.py
+++ b/app.py
@@ -3,12 +3,16 @@
 import os
 import json
 import traceback
-from typing import List
+from typing import Dict, List, Optional
 
 from flask import Flask, jsonify, request
 from groq import Groq
 import serverless_wsgi
 from dotenv import load_dotenv, find_dotenv
+try:
+    import psycopg2
+except ImportError:  # pragma: no cover
+    psycopg2 = None
 
 # ---------- Environment & App setup ----------
 # Load .env from current directory or parent directories so a project-level .env is picked up.
@@ -31,6 +35,7 @@ print("GROQ key present at startup:", bool(os.getenv("GROQ_API_KEY")))
 client = Groq(api_key=os.getenv("GROQ_API_KEY"))
 
 MODEL_NAME = "llama-3.1-8b-instant"
+DB_SCHEMA = os.getenv("DB_SCHEMA", "virginia_dev_saayam_rdbms")
 
 # ---------- Categories / Prompts ----------
 categories: List[str] = [
@@ -91,6 +96,175 @@ def _parse_categories(raw: str) -> List[str]:
     parts = [p.strip() for p in raw.replace("\n", ",").split(",")]
     return [p for p in parts if p in categories][:3]
 
+
+def _first_non_empty(data: dict, keys: List[str]) -> str:
+    for key in keys:
+        value = data.get(key)
+        if isinstance(value, str):
+            value = value.strip()
+            if value:
+                return value
+    return ""
+
+
+def _normalize_history(history: Optional[list]) -> List[Dict[str, str]]:
+    if not isinstance(history, list):
+        return []
+
+    normalized: List[Dict[str, str]] = []
+    for msg in history:
+        if not isinstance(msg, dict):
+            continue
+        role = str(msg.get("role", "")).strip().lower()
+        content = str(msg.get("content", "")).strip()
+        if not content:
+            continue
+
+        if role in {"ai", "bot", "model"}:
+            role = "assistant"
+        elif role not in {"user", "assistant", "system"}:
+            continue
+
+        normalized.append({"role": role, "content": content})
+    return normalized
+
+
+def _extract_request_payload() -> dict:
+    """
+    Accept both direct JSON payloads and nested proxy-like payloads:
+      { ...fields... }
+      { "body": { ...fields... } }
+      { "body": "{\"...\": \"...\"}" }
+    """
+    data = request.get_json(force=True, silent=True) or {}
+    if not isinstance(data, dict):
+        return {}
+
+    nested = data.get("body")
+    if isinstance(nested, dict):
+        merged = dict(data)
+        merged.pop("body", None)
+        merged.update(nested)
+        return merged
+
+    if isinstance(nested, str):
+        try:
+            parsed = json.loads(nested)
+            if isinstance(parsed, dict):
+                merged = dict(data)
+                merged.pop("body", None)
+                merged.update(parsed)
+                return merged
+        except json.JSONDecodeError:
+            pass
+
+    return data
+
+
+def _get_db_connection():
+    if psycopg2 is None:
+        raise RuntimeError("psycopg2 is not installed")
+
+    required = ["DB_HOST", "DB_PORT", "DB_NAME", "DB_USER", "DB_PASSWORD"]
+    missing = [name for name in required if not os.getenv(name)]
+    if missing:
+        raise RuntimeError(f"Missing DB env vars: {', '.join(missing)}")
+
+    return psycopg2.connect(
+        host=os.getenv("DB_HOST"),
+        port=os.getenv("DB_PORT"),
+        dbname=os.getenv("DB_NAME"),
+        user=os.getenv("DB_USER"),
+        password=os.getenv("DB_PASSWORD"),
+    )
+
+
+def _format_additional_info_for_prompt(additional_info: List[Dict[str, object]]) -> str:
+    lines: List[str] = []
+    for entry in additional_info:
+        question = entry.get("question")
+        answers = entry.get("answers", [])
+        if not question or not isinstance(answers, list) or not answers:
+            continue
+        rendered = ", ".join(str(ans) for ans in answers if ans not in (None, ""))
+        if rendered:
+            lines.append(f"- {question}: {rendered}")
+    return "\n".join(lines)
+
+
+def get_request_full_details(user_id: str, req_id: str) -> Dict[str, object]:
+    query = f"""
+        SELECT
+            r.req_id,
+            r.req_user_id,
+            r.req_cat_id,
+            r.req_subj,
+            r.req_desc,
+            r.req_loc,
+            m.field_name_key AS question,
+            m.field_type,
+            l.item_value AS list_answer,
+            rai.field_value
+        FROM {DB_SCHEMA}.request r
+        LEFT JOIN {DB_SCHEMA}.req_add_info rai
+            ON r.req_id = rai.req_id
+        LEFT JOIN {DB_SCHEMA}.req_add_info_metadata m
+            ON rai.field_id = m.field_id
+        LEFT JOIN {DB_SCHEMA}.list_item_metadata l
+            ON rai.item_id = l.item_id
+        WHERE r.req_user_id = %s
+          AND r.req_id = %s
+        ORDER BY rai.field_id;
+    """
+    conn = None
+    try:
+        conn = _get_db_connection()
+        cur = conn.cursor()
+        cur.execute(query, (user_id, req_id))
+        rows = cur.fetchall()
+        cols = [desc[0] for desc in cur.description]
+        if not rows:
+            return {"error": f"No data found for user_id={user_id}, req_id={req_id}"}
+
+        first = rows[0]
+        col = {name: idx for idx, name in enumerate(cols)}
+        result: Dict[str, object] = {
+            "req_id": first[col["req_id"]],
+            "req_user_id": first[col["req_user_id"]],
+            "req_cat_id": first[col["req_cat_id"]],
+            "req_subj": first[col["req_subj"]],
+            "req_desc": first[col["req_desc"]],
+            "req_loc": first[col["req_loc"]],
+            "additional_info": [],
+        }
+
+        grouped: Dict[str, Dict[str, object]] = {}
+        for row in rows:
+            question = row[col["question"]]
+            if not question:
+                continue
+            entry = grouped.setdefault(
+                str(question),
+                {
+                    "question": str(question),
+                    "field_type": row[col["field_type"]],
+                    "answers": [],
+                },
+            )
+            list_answer = row[col["list_answer"]]
+            field_value = row[col["field_value"]]
+            answer = list_answer if list_answer not in (None, "") else field_value
+            if answer not in (None, "") and answer not in entry["answers"]:
+                entry["answers"].append(str(answer))
+
+        result["additional_info"] = list(grouped.values())
+        return result
+    except Exception as exc:
+        return {"error": str(exc)}
+    finally:
+        if conn:
+            conn.close()
+
 # ---------- Core LLM calls ----------
 def predict_categories(subject: str, description: str) -> List[str]:
     prompt = f"""
@@ -121,16 +295,39 @@ Output (comma-separated categories):
     return result
 
 
-def chat_with_llama(category: str, subject: str, description: str) -> str:
+def chat_with_llama(
+    category: str,
+    subject: str,
+    description: str,
+    location: str = "",
+    gender: str = "",
+    age: str = "",
+    conversation_history: Optional[List[Dict[str, str]]] = None,
+) -> str:
     role_prompt = category_prompts.get(
         category,
         "You are a helpful expert from Saayam. Answer the question clearly and kindly:",
     )
-    full_prompt = f"{role_prompt}\n\nSubject: {subject}\nQuestion: {description}"
+
+    base_prompt = (
+        f"{role_prompt}\n\n"
+        f"Subject: {subject}\n"
+        f"Question: {description}\n"
+        f"Location: {location}\n"
+        f"Gender: {gender}\n"
+        f"Age: {age}"
+    )
+    messages: List[Dict[str, str]] = [{"role": "user", "content": base_prompt}]
+    if conversation_history:
+        messages = [
+            {"role": "system", "content": role_prompt},
+            *conversation_history,
+            {"role": "user", "content": f"Subject: {subject}\nQuestion: {description}"},
+        ]
 
     resp = client.chat.completions.create(
         model=MODEL_NAME,
-        messages=[{"role": "user", "content": full_prompt}],
+        messages=messages,
         temperature=0.7,
     )
     return resp.choices[0].message.content.strip()
@@ -140,10 +337,12 @@ def chat_with_llama(category: str, subject: str, description: str) -> str:
 def home():
     return jsonify({"message": "API is running"})
 
-@app.route("/predict_categories", methods=["POST"])
+@app.route("/predict_categories", methods=["POST", "OPTIONS"])
 def predict_categories_api():
     try:
-        data = request.get_json(force=True) or {}
+        if request.method == "OPTIONS":
+            return ("", 200)
+        data = _extract_request_payload()
         subject = (data.get("subject") or "").strip()
         description = (data.get("description") or "").strip()
         if not subject or not description:
@@ -155,22 +354,107 @@ def predict_categories_api():
         traceback.print_exc()
         return jsonify({"error": "internal_error"}), 500
 
-@app.route("/generate_answer", methods=["POST"])
+@app.route("/generate_answer", methods=["POST", "OPTIONS"])
 def generate_answer_api():
     try:
-        data = request.get_json(force=True) or {}
-        category = (data.get("category") or "").strip()
-        subject = (data.get("subject") or "").strip()
-        question = (data.get("description") or "").strip()
-        if not category or not subject or not question:
-            return jsonify({"error": "Category, subject, and description are required"}), 400
-
-        answer = chat_with_llama(category, subject, question)
-        # jsonify(answer) returns a JSON string (what your existing client likely expects)
+        if request.method == "OPTIONS":
+            return ("", 200)
+        data = _extract_request_payload()
+        answer, error_message, status_code = _generate_answer_from_payload(data)
+        if error_message:
+            return jsonify({"error": error_message}), status_code
+        # Backward compatibility for existing consumers expecting a JSON string.
         return jsonify(answer), 200
     except Exception:
         traceback.print_exc()
         return jsonify({"error": "internal_error"}), 500
+
+
+def _generate_answer_from_payload(data: dict):
+    try:
+        category = _first_non_empty(data, ["category", "category_id"])
+        subject = _first_non_empty(data, ["subject"])
+        question = _first_non_empty(data, ["description", "question"])
+        location = _first_non_empty(data, ["location"])
+        gender = _first_non_empty(data, ["gender"])
+        age = _first_non_empty(data, ["age"])
+        lookup_error = ""
+
+        # Wiki-aligned fallback: if user_id + req_id are provided, load request context from DB.
+        user_id = _first_non_empty(data, ["user_id", "req_user_id"])
+        req_id = _first_non_empty(data, ["req_id", "request_id", "id"])
+        if user_id and req_id and (not category or not subject or not question):
+            request_details = get_request_full_details(user_id, req_id)
+            if "error" in request_details:
+                lookup_error = str(request_details["error"])
+            else:
+                category = category or str(request_details.get("req_cat_id") or "")
+                subject = subject or str(request_details.get("req_subj") or "")
+                location = location or str(request_details.get("req_loc") or "")
+                if not question:
+                    base_desc = str(request_details.get("req_desc") or "")
+                    additional_info = request_details.get("additional_info") or []
+                    context = _format_additional_info_for_prompt(additional_info)
+                    question = (
+                        f"{base_desc}\n\nAdditional details:\n{context}"
+                        if context
+                        else base_desc
+                    )
+
+        conversation_history = _normalize_history(
+            data.get("conversation_history", data.get("chat_history"))
+        )
+        if not category or not subject or not question:
+            message = "category/category_id, subject, and description/question are required"
+            if lookup_error:
+                message = f"{message}. DB lookup error: {lookup_error}"
+            return None, message, 400
+
+        answer = chat_with_llama(
+            category,
+            subject,
+            question,
+            location=location,
+            gender=gender,
+            age=age,
+            conversation_history=conversation_history,
+        )
+        return answer, None, 200
+    except Exception:
+        traceback.print_exc()
+        return None, "internal_error", 500
+
+
+@app.route("/generate_answer_api", methods=["POST", "OPTIONS"])
+def generate_followup_answer_api():
+    # UI expects payload shape: { body: { answer: "<text>" } }.
+    # Keep top-level `answer` as a compatibility convenience.
+    try:
+        if request.method == "OPTIONS":
+            return ("", 200)
+        data = _extract_request_payload()
+        answer, error_message, status_code = _generate_answer_from_payload(data)
+        if error_message:
+            return jsonify({"error": error_message}), status_code
+        return jsonify({"answer": answer, "body": {"answer": answer}}), 200
+    except Exception:
+        traceback.print_exc()
+        return jsonify({"error": "internal_error"}), 500
+
+
+@app.route("/v1/genai/predict_categories", methods=["POST", "OPTIONS"])
+def v1_predict_categories_api():
+    return predict_categories_api()
+
+
+@app.route("/v1/genai/generate_answer", methods=["POST", "OPTIONS"])
+def v1_generate_answer_api():
+    return generate_answer_api()
+
+
+@app.route("/v1/genai/generate_answer_api", methods=["POST", "OPTIONS"])
+def v1_generate_followup_answer_api():
+    return generate_followup_answer_api()
 
 # ---------- Lambda entry ----------
 def lambda_handler(event, context):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+flask
+groq
+python-dotenv
+serverless-wsgi
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ groq
 python-dotenv
 serverless-wsgi
 requests
+psycopg2-binary


### PR DESCRIPTION
## Summary
- Add payload compatibility for `generate_answer_api` to support both UI chat payloads `user_id + req_id` style lookups
- Add DB fallback retrieval for `user_id/req_id` using request + additional-info tables
- Normalize conversation history roles and include request context in prompts
- Add `/v1/genai/*` route aliases and OPTIONS handling
- Return UI-compatible response shape for follow-up chat: `{"body": {"answer": ...}}` (also includes top-level `answer` for compatibility)
- Add `psycopg2-binary` dependency

## Why
Current deployed endpoint behavior requires only `user_id/req_id`, while webapp follow-up chat sends `category_id + subject + description + conversation_history`. This change makes backend compatible with both payload styles.

## Local Validation
- Verified `/generate_answer_api` with:
  - UI follow-up payload
  - payload (`user_id`, `req_id`, `conversation_history`)
  - nested `body` object payload
  - nested `body` JSON-string payload
- Verified legacy `/generate_answer` response compatibility