### PR TITLE
Add hierarchy field

### DIFF
--- a/services/classification_service.py
+++ b/services/classification_service.py
@@ -6,6 +6,7 @@ from utils.categories import (
     category_name_to_number,
     get_top_level_categories,
     get_direct_children,
+    get_category_hierarchy,
 )
 from utils.routing_for_categories import is_elderly_context
 
@@ -312,6 +313,7 @@ class GroqClassificationService:
                             "category_number": category_id,
                             "category_name": category_name,
                             "confidence": item.get("confidence", 0.0),
+                            "hierarchy": get_category_hierarchy(category_id),
                         }
                     )
                     if len(results) >= 3:

--- a/utils/categories.py
+++ b/utils/categories.py
@@ -121,5 +121,20 @@ def get_direct_children(parent_id: str) -> list[str]:
     return children
 
 
+def get_category_hierarchy(category_id: str) -> str:
+    """Build a human-readable hierarchy path for a given category ID.
+
+    Example: "4.3.1" -> "Education Career Support > Tutoring > Math"
+    """
+    parts = category_id.split(".")
+    path = []
+    for i in range(1, len(parts) + 1):
+        ancestor_id = ".".join(parts[:i])
+        name = help_categories.get(ancestor_id, "")
+        if name:
+            path.append(name.replace("_", " ").title())
+    return " > ".join(path)
+
+
 # Create a dictionary for faster lookups
 category_name_to_number = {name: number for number, name in help_categories.items()}


### PR DESCRIPTION
Description:

Added a hierarchy field to each predicted category in the response, showing the full path from the root category down to the predicted leaf.

Example output:

{
  "category_number": "4.3.1",
  "category_name": "MATH",
  "confidence": 0.95,
  "hierarchy": "Education Career Support > Tutoring > Math"
}