### PR TITLE
Add torch to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 flask
 transformers
+torch
 meta-ai-api
 google-generativeai
 openai


### PR DESCRIPTION
The transformers zero-shot-classification pipeline (used at app.py:76 for category prediction) requires a PyTorch or TensorFlow backend. With only transformers listed, a fresh install per the README fails at startup with:

    NameError: name 'torch' is not defined

Adding torch unblocks fresh setups by new contributors.