### PR TITLE
Optimize Generate Subject prompt for fidelity, concision, and non-misleading framing (#137)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .env
 venv
+.venv
 __pycache__
 *.pyc
+local_test.py
+aws_test.py

--- a/test_subject_generator.py
+++ b/test_subject_generator.py
@@ -1,0 +1,88 @@
+"""
+Unit tests for the Generate Subject service.
+
+These tests mock the LLM entirely — they make NO network calls and do NOT touch
+AWS SSM or any external model. Importing utils.subject_generator triggers the
+SSM bootstrap in utils.client, which fails gracefully (no creds) and leaves the
+LLM handles as None; the tests then inject a fake LLM in the module namespace.
+"""
+import utils.subject_generator as sg
+
+
+class _FakeMessage:
+    def __init__(self, content):
+        self.content = content
+
+
+class _FakeLLM:
+    """Stands in for a LangChain chat model: .invoke(prompt) -> obj with .content."""
+    def __init__(self, content):
+        self._content = content
+
+    def invoke(self, _prompt):
+        return _FakeMessage(self._content)
+
+
+def _use_fake(monkeypatch, content):
+    monkeypatch.setattr(sg, "groq_llm", _FakeLLM(content))
+    monkeypatch.setattr(sg, "_use_groq", True)
+    monkeypatch.setattr(sg, "gemini_llm", None)
+    monkeypatch.setattr(sg, "_use_gemini", False)
+
+
+# ---------- _clean_subject ----------
+
+def test_clean_subject_strips_leading_label():
+    assert sg._clean_subject("Subject: Roommate Wanted") == "Roommate Wanted"
+    assert sg._clean_subject("Title - Toothache Relief") == "Toothache Relief"
+
+
+def test_clean_subject_strips_surrounding_quotes():
+    assert sg._clean_subject('"Ear Congestion and Ringing"') == "Ear Congestion and Ringing"
+    assert sg._clean_subject("'General Checkup'") == "General Checkup"
+
+
+def test_clean_subject_strips_label_and_quotes_together():
+    assert sg._clean_subject('Subject: "Heart Concern"') == "Heart Concern"
+
+
+def test_clean_subject_empty_falls_back():
+    assert sg._clean_subject("") == "General Inquiry"
+    assert sg._clean_subject("   ") == "General Inquiry"
+
+
+# ---------- _truncate_with_word_boundary ----------
+
+def test_truncate_enforces_max_length():
+    out = sg._truncate_with_word_boundary("word " * 40, 70)
+    assert len(out) <= 70
+
+
+# ---------- generate_subject_from_description ----------
+
+def test_generate_cleans_label_and_quotes(monkeypatch):
+    _use_fake(monkeypatch, 'Subject: "Single Male Roommate for Rent"')
+    result = sg.generate_subject_from_description("Looking for a roommate to share a room for rent.")
+    assert result == "Single Male Roommate for Rent"
+
+
+def test_generate_enforces_max_length(monkeypatch):
+    _use_fake(monkeypatch, "This is an excessively long subject line " * 5)
+    result = sg.generate_subject_from_description("Some description text here.", max_length=70)
+    assert len(result) <= 70
+
+
+def test_generate_empty_description_returns_fallback():
+    assert sg.generate_subject_from_description("") == "General Inquiry"
+    assert sg.generate_subject_from_description("   ") == "General Inquiry"
+
+
+def test_generate_falls_back_to_description_when_no_llm(monkeypatch):
+    monkeypatch.setattr(sg, "_use_groq", False)
+    monkeypatch.setattr(sg, "groq_llm", None)
+    monkeypatch.setattr(sg, "_use_gemini", False)
+    monkeypatch.setattr(sg, "gemini_llm", None)
+    desc = "I need help finding a food bank near me this week."
+    result = sg.generate_subject_from_description(desc)
+    assert result  # non-empty
+    assert len(result) <= 70

--- a/utils/subject_generator.py
+++ b/utils/subject_generator.py
@@ -1,4 +1,19 @@
+import re
+
 from utils.client import groq_llm, gemini_llm, _use_groq, _use_gemini
+
+# Strips a leading "Subject:" / "Title:" label that some models prepend despite
+# being told not to.
+_LABEL_RE = re.compile(r"^\s*(subject|title)\s*[:\-]\s*", re.IGNORECASE)
+
+
+def _clean_subject(text) -> str:
+    """Normalize a raw LLM subject: drop a leading label and surrounding quotes."""
+    s = str(text).strip()
+    s = _LABEL_RE.sub("", s)
+    s = s.strip().strip('"').strip("'").strip()
+    return s or "General Inquiry"
+
 
 def _truncate_with_word_boundary(text: str, max_length: int) -> str:
     """
@@ -36,12 +51,24 @@ def generate_subject_from_description(description: str, max_length: int = 70) ->
     description = description.strip()
 
     # declaring prompt
-    prompt = f"""Generate a concise subject/title (maximum {max_length} characters) that summarizes the following description. 
-Return ONLY the subject, no additional text or explanation. Keep it brief and descriptive.
+    prompt = f"""You are writing the subject line for a help request. Produce ONE concise, specific subject (max {max_length} characters) for the description below. Write it as the person's own request or concern, never as a diagnosis or clinical assessment.
 
-Description: {description}
+Rules:
+- Write a concise noun phrase, like a news headline.
+- Include the specific details actually stated (symptoms, who it's for, type, timeframe), and keep meaning-critical words exactly (e.g. "roommate" is not "room").
+- If the person raises a possible cause, body part, or specialty they are worried about (e.g. "not sure if it's my heart"), keep that cue but frame it as THEIR concern (e.g. "Heart Concern"), NOT as a diagnosis. Do not add words like "Possible", "Issue", "Condition", or "Disorder" that they did not say.
+- Do not introduce assessment, severity, or certainty words the person did not use (e.g. "severe", "chronic", "acute", "unexplained").
+- Do NOT over-generalize away specifics: keep "ringing / congestion" (not "ear problem"); keep BOTH symptoms if two are stated; keep a stated timeframe like "short/mid term".
+- Name the thing itself; do NOT append status words like "Needed", "Required", "Wanted", "Seeking", "Request", "Assistance", or "Appointment". E.g. "Knee Injury Physiotherapy Needed" -> "Knee Injury Physiotherapy".
+- Do not invent details.
+- Output ONLY the subject text: no quotes, no "Subject:"/"Title:" label, no explanation.
 
-Subject (max {max_length} chars)"""
+Examples (description -> subject):
+"My ears feel clogged and are ringing lately." -> Ear Congestion and Ringing
+"I feel tired and short of breath on stairs, not sure if it's my heart." -> Fatigue and Breathlessness, Heart Concern
+"Single male looking for a roommate to share a room for rent, short/mid term." -> Single Male Roommate for Rent (Short/Mid Term)
+
+Description: {description}"""
 
     # ---------- CASE 1: Short description ----------
 
@@ -55,7 +82,7 @@ Subject (max {max_length} chars)"""
             try:
                 ai_message = groq_llm.invoke(prompt)
                 content = getattr(ai_message, "content", None) or ""
-                generated_subject = str(content).strip().strip('"').strip("'") or "General Inquiry"
+                generated_subject = _clean_subject(content)
 
                 # Strictly enforce max_length - truncate if necessary
                 if len(generated_subject) <= max_length:
@@ -69,7 +96,7 @@ Subject (max {max_length} chars)"""
             try:
                 ai_message = gemini_llm.invoke(prompt)
                 content = getattr(ai_message, "content", None) or ""
-                generated_subject = str(content).strip().strip('"').strip("'") or "General Inquiry"
+                generated_subject = _clean_subject(content)
 
                 # Strictly enforce max_length - truncate if necessary
                 if len(generated_subject) <= max_length:


### PR DESCRIPTION
## Summary

Optimizes the Generate Subject prompt (`utils/subject_generator.py`) so generated subjects are faithful, concise, and framed as the requester's own concern rather than a clinical assessment. Addresses #137.

## Problem

The previous prompt only asked the model to "summarize / be brief". Observed issues:
- Paraphrased away meaning-critical words (reported example: "roommate" → "room").
- Dropped key qualifiers (e.g. "short/mid term") and named cues (e.g. a "heart" concern in an ambiguous case).
- Occasionally emitted a `Subject:` prefix or surrounding quotes that were never stripped.

## Changes

- Reworked the prompt to:
  - keep meaning-critical words and the specific details actually stated (symptoms, who it's for, timeframe), and avoid over-generalizing;
  - write the subject in the requester's own voice — never as a diagnosis or clinical assessment — and never introduce assessment/severity words the requester did not use;
  - when a requester tentatively names a cause they are worried about (e.g. "not sure if it's my heart"), keep that cue framed as **their concern** ("Heart Concern"), not a diagnosis;
  - produce a concise noun phrase with no status filler ("Needed"/"Seeking"); output only the subject (no label or quotes).
- Added `_clean_subject()` to strip any stray `Subject:`/`Title:` label and surrounding quotes at all generation sites.
- Added unit tests for the subject-generation logic.

## Key handling / infrastructure

**No changes to key handling.** The service still fetches the Groq/Gemini keys from AWS SSM Parameter Store via `utils/client.py`, exactly as before — `client.py` is untouched.

## Testing

- 9 unit tests pass locally (`pytest test_subject_generator.py`). The tests mock the LLM and make no network calls (no AWS, no external model).
- Behavior was validated across a 47-case corpus (medical + housing) on a Llama-3.1-8B-Instruct model matching the production Groq model family: meaning-critical cues preserved, no filler, no misleading assessment-voice framing, and all subjects within the 70-character limit.

## Notes

- Final confirmation on the production Groq endpoint is recommended once AWS Parameter Store access is available for local testing.
