### PR TITLE
Fix Organizations search: replace decommissioned Groq model (llama-4-scout -> llama-3.3-70b)

### DIFF
--- a/test_search_orgs.py
+++ b/test_search_orgs.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for the More Organizations (search_orgs) service.
+
+These tests make no network calls and do not touch AWS. Constructing a ChatGroq
+instance with a dummy key does not call the Groq API, so we can assert on its
+configuration safely.
+"""
+import pytest
+
+import utils.search_orgs as so
+
+# The model Groq decommissioned (returned 404 model_not_found), which broke the
+# Organizations feature. Guard against reintroducing it.
+DECOMMISSIONED_MODEL = "meta-llama/llama-4-scout-17b-16e-instruct"
+
+
+def test_load_llm_uses_supported_model(monkeypatch):
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    llm = so.load_llm()
+    assert llm.model_name == "llama-3.3-70b-versatile"
+    assert llm.model_name != DECOMMISSIONED_MODEL
+
+
+def test_load_llm_requires_key(monkeypatch):
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        so.load_llm()
+
+
+def test_build_prompt_exposes_expected_variables():
+    prompt = so.build_prompt("shelter", "need a place to stay", "Tampa")
+    assert {"subject", "description", "location", "format_instructions"} <= set(prompt.input_variables)
+
+
+def test_parser_targets_organization_list():
+    fmt = so.parser.get_format_instructions()
+    assert "organizations" in fmt.lower()

--- a/utils/search_orgs.py
+++ b/utils/search_orgs.py
@@ -42,7 +42,7 @@ def load_llm():
         raise ValueError("Missing GROQ_API_KEY in environment variables.")
     print("Using Groq model")
     return ChatGroq(
-        model="meta-llama/llama-4-scout-17b-16e-instruct",
+        model="llama-3.3-70b-versatile",
         temperature=0.1,
         groq_api_key=groq_key,
     )


### PR DESCRIPTION
## Summary

Fixes the **More Organizations** feature, which was failing because Groq decommissioned the model it used. Swaps to a currently-supported model.

## Problem

`utils/search_orgs.py` called `meta-llama/llama-4-scout-17b-16e-instruct`, which Groq has removed. Direct calls now return `404 model_not_found` ("The model ... does not exist or you do not have access to it") — which surfaced as an apparent "access/key expired" error. The API key is valid: every other GenAI feature uses `llama-3.1-8b-instant`, which is still live, so the shared key is fine. Only this one model is gone.

## Change

- Swap the model in `load_llm()` to **`llama-3.3-70b-versatile`** — a currently-supported Meta Llama model (70B) well-suited to the structured 6-organization JSON output this feature produces.
- Add a unit test that guards against reintroducing the decommissioned model.

## Testing

- Validated live against the real chain (`prompt | llm | JsonOutputParser`): the new model returns 6 correctly-typed, parseable organizations (e.g. for a Tampa shelter query: Metropolitan Ministries, Tampa YMCA, ...).
- 4 unit tests pass locally (`pytest test_search_orgs.py`); they make no network calls and do not touch AWS.

## Key handling / infrastructure

No changes to key handling — the model string is the only change; `client.py` and the SSM/env key flow are untouched.
